### PR TITLE
Fix for connection problemens / comm errors

### DIFF
--- a/OmniCore.Mobile/OmniCore.Mobile.Android/MainActivity.cs
+++ b/OmniCore.Mobile/OmniCore.Mobile.Android/MainActivity.cs
@@ -31,6 +31,8 @@ namespace OmniCore.Mobile.Android
         public const string IntentEnsureServiceRunning = "EnsureServiceRunning";
         protected override void OnCreate(Bundle savedInstanceState)
         {
+            ToggleAdapter();
+
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
             base.OnCreate(savedInstanceState);
@@ -51,6 +53,27 @@ namespace OmniCore.Mobile.Android
             i.SetAction(OmniCoreIntentService.ACTION_START_SERVICE);
             StartService(i);
             IsCreated = true;
+        }
+
+        private void ToggleAdapter()
+        {
+            try
+            {
+                if (CrossBleAdapter.Current.CanControlAdapterState())
+                {
+                    // Switch adapter on if off (testing)
+                    if (CrossBleAdapter.Current.Status == AdapterStatus.PoweredOff)
+                    {
+                        CrossBleAdapter.Current.SetAdapterState(true);
+                        Wait(5000);
+                    }
+                }
+            }
+            catch
+            {
+                // TODO: We'll handle this later...
+                // Try continuing
+            }
         }
 
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Permission[] grantResults)

--- a/OmniCore.Mobile/OmniCore.Mobile.Android/Properties/AndroidManifest.xml
+++ b/OmniCore.Mobile/OmniCore.Mobile.Android/Properties/AndroidManifest.xml
@@ -3,4 +3,6 @@
 	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="28" />
 	<application android:label="OmniCore" android:largeHeap="true"></application>
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+	<uses-permission android:name="android.permission.BLUETOOTH"/>
+	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 </manifest>

--- a/OmniCore.Model/OmniCore.Model.Eros/ErosPodManager.cs
+++ b/OmniCore.Model/OmniCore.Model.Eros/ErosPodManager.cs
@@ -134,7 +134,7 @@ namespace OmniCore.Model.Eros
                 progress.ActionText = "Started new message exchange";
                 progress.Result.RequestTime = DateTimeOffset.UtcNow;
                 progress.Running = true;
-                var messageExchange = await MessageExchangeProvider.GetMessageExchange(messageExchangeParameters, Pod);
+                var messageExchange = await MessageExchangeProvider.GetMessageExchange(messageExchangeParameters, Pod, progress);
                 await messageExchange.InitializeExchange(progress);
                 var response = await messageExchange.GetResponse(requestMessage, progress);
 
@@ -144,7 +144,7 @@ namespace OmniCore.Model.Eros
                 {
                     var responseMessage = response as ErosMessage;
                     emp.MessageSequenceOverride = (responseMessage.sequence + 15) % 16;
-                    messageExchange = await MessageExchangeProvider.GetMessageExchange(messageExchangeParameters, Pod);
+                    messageExchange = await MessageExchangeProvider.GetMessageExchange(messageExchangeParameters, Pod, progress);
                     await messageExchange.InitializeExchange(progress);
                     response = await messageExchange.GetResponse(requestMessage, progress);
                     messageExchange.ParseResponse(response, Pod, progress);

--- a/OmniCore.Model/OmniCore.Model/Interfaces/IMessageExchangeProvider.cs
+++ b/OmniCore.Model/OmniCore.Model/Interfaces/IMessageExchangeProvider.cs
@@ -10,6 +10,6 @@ namespace OmniCore.Model.Interfaces
 {
     public interface IMessageExchangeProvider
     {
-        Task<IMessageExchange> GetMessageExchange(IMessageExchangeParameters messageExchangeParameters, IPod pod);
+        Task<IMessageExchange> GetMessageExchange(IMessageExchangeParameters messageExchangeParameters, IPod pod, IMessageExchangeProgress messageProgress);
     }
 }

--- a/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLink.cs
+++ b/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLink.cs
@@ -201,15 +201,19 @@ namespace OmniCore.Radio.RileyLink
         {
             Boolean result = false;
 
-            if (this.Device != null && this.Device.IsConnected())
+            if (this.Device != null)
             {
-                try
+                if (this.Device.IsConnected())
                 {
-                    await EnsureDevice(messageProgress);
-                    result = true; 
-                }
-                catch (OmniCoreRadioException) {
-                    // Ignored, just return false
+                    try
+                    {
+                        await EnsureDevice(messageProgress);
+                        result = true;
+                    }
+                    catch (OmniCoreRadioException)
+                    {
+                        // Ignored, just return false
+                    }
                 }
             }
 

--- a/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLink.cs
+++ b/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLink.cs
@@ -54,7 +54,7 @@ namespace OmniCore.Radio.RileyLink
 
         public RileyLink(ErosRadioPreferences erosRadioPreferences)
         {
-            TxAmplification = TxPower.A4_Normal;
+            TxAmplification = TxPower.A5_High; // On initialisation, start with some extra TxPower (it will auto adjust)
             Preferences = erosRadioPreferences;
         }
 

--- a/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLinkMessageExchangeProvider.cs
+++ b/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLinkMessageExchangeProvider.cs
@@ -17,8 +17,23 @@ namespace OmniCore.Radio.RileyLink
         private static RileyLinkMessageExchange RileyLinkMessageExchange;
 
         [method: SuppressMessage("", "CS1998", Justification = "Not applicable")]
-        public async Task<IMessageExchange> GetMessageExchange(IMessageExchangeParameters messageExchangeParameters, IPod pod)
+        public async Task<IMessageExchange> GetMessageExchange(IMessageExchangeParameters messageExchangeParameters, IPod pod, IMessageExchangeProgress messageProgress)
         {
+            if (RileyLinkInstance != null)
+            {
+                // Make sure this instance is still valid
+                if (!await RileyLinkInstance.DeviceIsValid(messageProgress))
+                {
+                    if (messageProgress != null)
+                        messageProgress.ActionText = "Reconnecting to RileyLink";
+
+                    // Dispose() and create new RileyLinkInstance
+                    RileyLinkInstance = null;
+                    // Dispose() and create new RileyLinkMessageExchange
+                    RileyLinkMessageExchange = null;
+                }
+            }
+
             if (RileyLinkInstance == null)
             {
                 RileyLinkInstance = new RileyLink(ErosRepository.Instance.GetRadioPreferences());

--- a/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLinkMessageExchangeProvider.cs
+++ b/OmniCore.Radio/OmniCore.Radio.RileyLink/RileyLinkMessageExchangeProvider.cs
@@ -24,9 +24,6 @@ namespace OmniCore.Radio.RileyLink
                 // Make sure this instance is still valid
                 if (!await RileyLinkInstance.DeviceIsValid(messageProgress))
                 {
-                    if (messageProgress != null)
-                        messageProgress.ActionText = "Reconnecting to RileyLink";
-
                     // Dispose() and create new RileyLinkInstance
                     RileyLinkInstance = null;
                     // Dispose() and create new RileyLinkMessageExchange


### PR DESCRIPTION
In essence this fix (more like a work around) solves unexpected behavior of the BL library where reconnecting to RL results in a connective state where communications are impossible. 

As a result OmniCore kept reconnecting (EnsureDevice) en trying to send messages to RL with no avail.
Only way to get out of this was forcefully restarting OmniCore and BT toggling.

The fix disposes of and recreate the RileyLink instance as soon as it gets in this unexpected state to reinitializing RL and restore communications.
